### PR TITLE
gh_actions/fix_test_failure

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
       image: perl:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Configure git
         run: git config --system --add safe.directory '*'
       - name: perl -V

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
       image: perl:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4
+      - uses: actions/checkout@v1
       - name: Configure git
         run: git config --system --add safe.directory '*'
       - name: perl -V

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
       image: perl:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4
       - name: Configure git
         run: git config --system --add safe.directory '*'
       - name: perl -V

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          # - '5.14'
-          # - '5.18'
+          - '5.14'
+          - '5.18'
           - '5.28'
           - 'latest'
 
@@ -24,7 +24,7 @@ jobs:
       image: perl:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3
       - name: Configure git
         run: git config --system --add safe.directory '*'
       - name: perl -V

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Run Cover
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
             ./Build install
             HARNESS_PERL_SWITCHES=-MDevel::Cover DEVEL_COVER_SELF=1 ./Build test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.14'
-          - '5.18'
+          # - '5.14'
+          # - '5.18'
           - '5.28'
           - 'latest'
 
@@ -24,7 +24,7 @@ jobs:
       image: perl:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure git
         run: git config --system --add safe.directory '*'
       - name: perl -V

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -147,7 +147,7 @@ subtest 'get_source from sub-directory' => sub {
     is $source->{name}, $file_path, 'Check path when the source file is not in a sub-directory';
 
     local $ENV{CHANGED_DIR} = 'project';
-    my $source = Devel::Cover::Report::Coveralls::get_source($file_path, sub { $_[0] == 6 ? 0 : undef } );
+    $source = Devel::Cover::Report::Coveralls::get_source($file_path, sub { $_[0] == 6 ? 0 : undef } );
     is $source->{name}, "project/$file_path", 'Check path when the source file is in a sub-directory';
 };
 


### PR DESCRIPTION
# Description
Fix test failure
- The `latest actions/checkout@v4` requires newer system libraries that are not available in `perl:5.14` and `perl:5.18`, so use `actions/checkout@v3` instead.

# Card
* https://app.clickup.com/t/20696747/CICD-924